### PR TITLE
[R180FLU-7237] iPad audio issue

### DIFF
--- a/src/ios/CDVAudioMRP.m
+++ b/src/ios/CDVAudioMRP.m
@@ -448,10 +448,7 @@
                 [avPlayer pause];
                 avPlayer = nil;
             }
-            if (self.avSession) {
-                [self.avSession setActive:NO error:nil];
-                self.avSession = nil;
-            }
+
             [[self soundCache] removeObjectForKey:mediaId];
             NSLog(@"iOS: AudioMRP with id %@ released", mediaId);
         }
@@ -582,9 +579,7 @@
                     errorMsg = @"iOS: Failed to start recording using AVAudioRecorder";
                 }
                 audioFile.recorder = nil;
-                if (weakSelf.avSession) {
-                    [weakSelf.avSession setActive:NO error:nil];
-                }
+
                 jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-audio-mrp.AudioMRP').onStatus", mediaId, MEDIA_ERROR, [weakSelf createMediaErrorWithCode:MEDIA_ERR_ABORTED message:errorMsg]];
                 [weakSelf.commandDelegate evalJs:jsString];
             }
@@ -647,7 +642,7 @@
 
 // Creates or gets the cached audio file resource object
 - (CDVAMRPAudioFile*)audioFileForResource:(NSString*)resourcePath withId:(NSString*)mediaId doValidation:(BOOL)bValidate forRecording:(BOOL)bRecord {
-    NSLog(@"iOS: Creating audioFile: path: %@, id: %@", resourcePath, mediaId);
+    NSLog(@"iOS: 15:37 Creating audioFile: path: %@, id: %@", resourcePath, mediaId);
     
     BOOL bError = NO;
     CDVAMRPMediaError errcode = MEDIA_ERR_NONE_SUPPORTED;
@@ -857,10 +852,6 @@
         jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-audio-mrp.AudioMRP').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_DECODE message:nil]];
     }
     
-    if (self.avSession) {
-        [self.avSession setActive:NO error:nil];
-    }
-    
     [self stopAudioMetering];
     [self.commandDelegate evalJs:jsString];
 }
@@ -883,10 +874,6 @@
         jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-audio-mrp.AudioMRP').onStatus", mediaId, MEDIA_STATE, MEDIA_PLAY_COMPLETE];
     } else {
         jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-audio-mrp.AudioMRP').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_DECODE message:nil]];
-    }
-    
-    if (self.avSession) {
-        [self.avSession setActive:NO error:nil];
     }
     
     [self stopAudioMetering];

--- a/src/ios/CDVAudioMRP.m
+++ b/src/ios/CDVAudioMRP.m
@@ -642,7 +642,7 @@
 
 // Creates or gets the cached audio file resource object
 - (CDVAMRPAudioFile*)audioFileForResource:(NSString*)resourcePath withId:(NSString*)mediaId doValidation:(BOOL)bValidate forRecording:(BOOL)bRecord {
-    NSLog(@"iOS: 15:37 Creating audioFile: path: %@, id: %@", resourcePath, mediaId);
+    NSLog(@"iOS: Creating audioFile: path: %@, id: %@", resourcePath, mediaId);
     
     BOOL bError = NO;
     CDVAMRPMediaError errcode = MEDIA_ERR_NONE_SUPPORTED;

--- a/src/ios/CDVAudioMRP.m
+++ b/src/ios/CDVAudioMRP.m
@@ -307,9 +307,7 @@
     if (playerError != nil) {
         NSLog(@"iOS: Failed to initialize AVAudioPlayer: %@\n", [playerError localizedDescription]);
         audioFile.player = nil;
-        if (self.avSession) {
-            [self.avSession setActive:NO error:nil];
-        }
+        
         bError = YES;
     } else {
         NSLog(@"iOS: prepareToPlay: Created media player");
@@ -598,9 +596,7 @@
                     NSString* msg = @"iOS: Error creating audio session, microphone permission denied.";
                     NSLog(@"%@", msg);
                     audioFile.recorder = nil;
-                    if (weakSelf.avSession) {
-                        [weakSelf.avSession setActive:NO error:nil];
-                    }
+                    
                     jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-audio-mrp.AudioMRP').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_ABORTED message:msg]];
                     [weakSelf.commandDelegate evalJs:jsString];
                 }
@@ -885,10 +881,6 @@
     NSString* mediaId = self.currMediaId;
     NSString* jsString = nil;
     jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-audio-mrp.AudioMRP').onStatus", mediaId, MEDIA_STATE, MEDIA_PLAY_COMPLETE];
-
-    if (self.avSession) {
-        [self.avSession setActive:NO error:nil];
-    }
     
     [self stopAudioMetering];
     [self.commandDelegate evalJs:jsString];

--- a/src/ios/CDVAudioMRP.m
+++ b/src/ios/CDVAudioMRP.m
@@ -308,7 +308,7 @@
         NSLog(@"iOS: Failed to initialize AVAudioPlayer: %@\n", [playerError localizedDescription]);
         audioFile.player = nil;
         if (self.avSession) {
-            //[self.avSession setActive:NO error:nil];
+            [self.avSession setActive:NO error:nil];
         }
         bError = YES;
     } else {
@@ -583,7 +583,7 @@
                 }
                 audioFile.recorder = nil;
                 if (weakSelf.avSession) {
-                    //[weakSelf.avSession setActive:NO error:nil];
+                    [weakSelf.avSession setActive:NO error:nil];
                 }
                 jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-audio-mrp.AudioMRP').onStatus", mediaId, MEDIA_ERROR, [weakSelf createMediaErrorWithCode:MEDIA_ERR_ABORTED message:errorMsg]];
                 [weakSelf.commandDelegate evalJs:jsString];
@@ -604,7 +604,7 @@
                     NSLog(@"%@", msg);
                     audioFile.recorder = nil;
                     if (weakSelf.avSession) {
-                        //[weakSelf.avSession setActive:NO error:nil];
+                        [weakSelf.avSession setActive:NO error:nil];
                     }
                     jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%@);", @"cordova.require('cordova-plugin-audio-mrp.AudioMRP').onStatus", mediaId, MEDIA_ERROR, [self createMediaErrorWithCode:MEDIA_ERR_ABORTED message:msg]];
                     [weakSelf.commandDelegate evalJs:jsString];
@@ -858,7 +858,7 @@
     }
     
     if (self.avSession) {
-        //[self.avSession setActive:NO error:nil];
+        [self.avSession setActive:NO error:nil];
     }
     
     [self stopAudioMetering];
@@ -886,7 +886,7 @@
     }
     
     if (self.avSession) {
-        //[self.avSession setActive:NO error:nil];
+        [self.avSession setActive:NO error:nil];
     }
     
     [self stopAudioMetering];
@@ -900,7 +900,7 @@
     jsString = [NSString stringWithFormat:@"%@(\"%@\",%d,%d);", @"cordova.require('cordova-plugin-audio-mrp.AudioMRP').onStatus", mediaId, MEDIA_STATE, MEDIA_PLAY_COMPLETE];
 
     if (self.avSession) {
-        //[self.avSession setActive:NO error:nil];
+        [self.avSession setActive:NO error:nil];
     }
     
     [self stopAudioMetering];


### PR DESCRIPTION
- Calls to `[self.avSession setActive:NO error:nil];` were causing this runtime error: `AVAudioSession.mm:646: -[AVAudioSession setActive:withOptions:error:]: Deactivating an audio session that has running I/O. All I/O should be stopped or paused prior to deactivating the audio session.`
- I removed all such calls and tested across different activities on an iPad 2.
- Why exactly removing those calls fixed the issue -- other than the obvious "don't do that" nature of the fix -- I don't know. However, some googling showed that this issue occurs often for apps that run within Cordova. This is apparently due to an interaction between Safari's audio playback and the plugin's AVAudioSession.
